### PR TITLE
add apply_immediately option to db instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,7 @@ resource "aws_rds_cluster_instance" "db" {
   engine_version          = "${var.mysql_version}"
   db_parameter_group_name = "${aws_db_parameter_group.db.name}"
   db_subnet_group_name    = "${aws_db_subnet_group.db.name}"
+  apply_immediately       = "${var.apply_immediately}"
 }
 
 ### dns records

--- a/variables.tf
+++ b/variables.tf
@@ -82,3 +82,8 @@ variable "dns_zone" {
 variable "dns_zone_id" {
   description = "The hosted zone id for internal dns, e.g., ZFD3TFKDJ1L"
 }
+
+variable "apply_immediately" {
+  description = "pecifies whether any database modifications are applied immediately, or during the next maintenance window"
+  default     = false
+}


### PR DESCRIPTION
add apply_immediately option to DB instance

this option for specifying whether any database modifications are applied immediately, or during the next maintenance window